### PR TITLE
Remove brotlipy dep and fix requirements

### DIFF
--- a/requirements_setup.txt
+++ b/requirements_setup.txt
@@ -1,4 +1,4 @@
 # Requirements required by this package:
 
-brotlipy==0.7.0
-Django==2.1.2
+brotli==1.0.7
+Django

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     author='Vasek Dohnal',
     author_email='vaclav.dohnal@gmail.com',
     packages=['django_brotli'],
-    install_requires=['django', 'brotlipy'],
+    install_requires=['django', 'brotli'],
     extras_require={
         ":python_version<'3.5'": ['typing'],
     },


### PR DESCRIPTION
Currently brotlipy is not supported on python 3.7 so it causes installation of this package to fail on python 3.7.

This PR removes that requirement from the setup.py (since AFAIK it wasn't used anyway) and additionally fixes the Django requirement to allow it to work on 1.11 rather than forcing version 2.1.2.