### PR TITLE
Make brotli configurable by environment variable

### DIFF
--- a/django_brotli/middleware.py
+++ b/django_brotli/middleware.py
@@ -22,7 +22,7 @@ __all__ = ["BrotliMiddleware"]
 
 
 def compress(obj):
-    return brotli.compress(obj, BROTLI_MODE, BRODLI_QUALITY)
+    return brotli.compress(obj, BROTLI_MODE, BROTLI_QUALITY)
 
 
 # noinspection PyClassHasNoInit

--- a/django_brotli/middleware.py
+++ b/django_brotli/middleware.py
@@ -16,7 +16,7 @@ except ImportError:
 RE_ACCEPT_ENCODING_BROTLI = re.compile(r"\bbr\b")
 MIN_LEN_FOR_RESPONSE_TO_PROCESS = 200
 BROTLI_MODE = getattr(brotli, os.environ.get("BROTLI_MODE", "MODE_GENERIC"))
-BROTLI_QUALITY = int(os.environ.get("BROTLI_QUALITY", 5))
+BROTLI_QUALITY = int(os.environ.get("BROTLI_QUALITY", 4))
 
 __all__ = ["BrotliMiddleware"]
 


### PR DESCRIPTION
This PR allows configuring compression level and compression mode via environment variables.

- [Django's default](https://github.com/django/django/blob/4.1.4/django/utils/text.py#L318) gzip compression level is 6 out of 9.
- [Brotli's default](https://github.com/google/brotli/blob/v1.0.9/python/brotli.py#L33-L35) compression level is 11 out of 11.
- This PR sets django-brotli's default to 4 out of 11.

For a response with nearly 2MB uncompressed json payload containing many lists and dicts of english words (broti's strength), integers, and floats, a brotly quality setting of 5 or lower is needed avoid being slower than the gzip middleware (and still achieve 20% better compression ratio).

Setting the default quality to 4 makes brotli twice as fast as gzip@6, and still yields 20% better compression.

Benchmark:
```pycon
>>> payload = open('./payload.json', 'rb').read()
>>> len(payload)
1759385
>>> import gzip, brotli
>>> len(gzip.compress(payload, 6))
516307
>>> len(brotli.compress(payload, quality=11))
328070
>>> len(brotli.compress(payload, quality=10))
336622
>>> len(brotli.compress(payload, quality=9))
361724
>>> len(brotli.compress(payload, quality=8))
366235
>>> len(brotli.compress(payload, quality=7))
371714
>>> len(brotli.compress(payload, quality=6))
381026
>>> len(brotli.compress(payload, quality=5))
394309
>>> len(brotli.compress(payload, quality=4))
419936
>>> len(brotli.compress(payload, quality=3))
483480
>>> len(brotli.compress(payload, quality=2))
499352
>>> %timeit gzip.compress(payload, 6)
77 ms ± 1.07 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
>>> %timeit brotli.compress(payload, quality=11)
4.16 s ± 137 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
>>> %timeit brotli.compress(payload, quality=10)
1.74 s ± 74.1 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
>>> %timeit brotli.compress(payload, quality=9)
178 ms ± 15.5 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
>>> %timeit brotli.compress(payload, quality=8)
134 ms ± 9.4 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
>>> %timeit brotli.compress(payload, quality=7)
111 ms ± 7.22 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
>>> %timeit brotli.compress(payload, quality=6)
80.9 ms ± 2.43 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
>>> %timeit brotli.compress(payload, quality=5)
74.9 ms ± 1.23 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
>>> %timeit brotli.compress(payload, quality=4)
38.2 ms ± 431 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
>>> %timeit brotli.compress(payload, quality=3)
24.6 ms ± 309 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
>>> %timeit brotli.compress(payload, quality=2)
21.3 ms ± 773 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```